### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ Examples
 [scripts & README]
 
   [get-pip.py]: https://raw.github.com/pypa/pip/master/contrib/get-pip.py
-  [image]: https://pypip.in/v/django-mips/badge.png
-  [1]: https://pypip.in/d/django-mips/badge.png
+  [image]: https://img.shields.io/pypi/v/django-mips.svg
+  [1]: https://img.shields.io/pypi/dm/django-mips.svg
   [scripts & README]: https://github.com/michal-stuglik/django-mips/tree/master/mips/example
   [psycopg2]: http://stickpeople.com/projects/python/win-psycopg/2.6.0/psycopg2-2.6.0.win32-py2.7-pg9.4.1-release.exe
   [pythonwin]: https://www.python.org/ftp/python/2.7.10/python-2.7.10.msi
@@ -247,8 +247,8 @@ Examples
 [scripts & README]
 
   [get-pip.py]: https://raw.github.com/pypa/pip/master/contrib/get-pip.py
-  [image]: https://pypip.in/v/django-mips/badge.png
-  [1]: https://pypip.in/d/django-mips/badge.png
+  [image]: https://img.shields.io/pypi/v/django-mips.svg
+  [1]: https://img.shields.io/pypi/dm/django-mips.svg
   [scripts & README]: https://github.com/michal-stuglik/django-mips/tree/master/mips/example
   [psycopg2]: http://stickpeople.com/projects/python/win-psycopg/2.6.0/psycopg2-2.6.0.win32-py2.7-pg9.4.1-release.exe
   [pythonwin]: https://www.python.org/ftp/python/2.7.10/python-2.7.10.msi


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-mips))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-mips`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.